### PR TITLE
Allows some comments after `end`

### DIFF
--- a/grammars/language-algol60.json
+++ b/grammars/language-algol60.json
@@ -48,6 +48,16 @@
 						}
 					},
 					"end": "(?=;)"
+				},
+				{
+					"contentName": "comment.block.algol60",
+					"begin": "\\bend\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.algol60"
+						}
+					},
+					"end": "(?=;|\\b(Boolean|array|else|end|integer|own|procedure|real|switch)\\b)"
 				}
 			]
 		},


### PR DESCRIPTION
This is a draft PR to allow comments after the `end`.
Related issue: #5 